### PR TITLE
Fix red color led channel lighting up slightly when below the threshold

### DIFF
--- a/src/kaleidoscope/device/dygma/raise/Hand.cpp
+++ b/src/kaleidoscope/device/dygma/raise/Hand.cpp
@@ -236,8 +236,8 @@ void Hand::sendLEDBank(uint8_t bank) {
     // reducing the red component a little.
     //
     // FIXME(@anyone): This should eventually be configurable someway.
-    if ((i + 1) % 3 == 1 && data[i + 1] >= 26) {
-      data[i + 1] -= 26;
+    if ((i + 1) % 3 == 1) {
+      data[i + 1] = (data[i + 1] >= 26) ? data[i + 1] - 26 : 0;
     }
   }
   uint8_t result = twi_.writeTo(data, ELEMENTS(data));


### PR DESCRIPTION
This fixes an issue when, for example, using the blazer trail stalker led effect, the keys would increase in brightness slightly at the end of the curve. This happens because of the workaround where 26 is removed from the red channel to fix an issue where the voltage to the red channel is slightly higher.