### PR TITLE
Significantly improve latency when using rainbow effect

### DIFF
--- a/src/kaleidoscope/plugin/HardwareTestMode.cpp
+++ b/src/kaleidoscope/plugin/HardwareTestMode.cpp
@@ -65,7 +65,7 @@ void HardwareTestMode::testLeds(void) {
   ::LEDControl.activate(&::LEDRainbowEffect);
 
   // rainbow for 10 seconds
-  ::LEDRainbowEffect.update_delay(5);
+  ::LEDControl.setTargetFPS(200);
   for (auto i = 0; i < 300; i++) {
     ::LEDControl.update();
     ::LEDControl.syncLeds();

--- a/src/kaleidoscope/plugin/LEDControl.cpp
+++ b/src/kaleidoscope/plugin/LEDControl.cpp
@@ -29,7 +29,7 @@ static constexpr uint8_t uninitialized_mode_id = 255;
 uint8_t LEDControl::mode_id = uninitialized_mode_id;
 uint8_t LEDControl::num_led_modes_ = LEDModeManager::numLEDModes();
 LEDMode *LEDControl::cur_led_mode_ = nullptr;
-uint8_t LEDControl::syncDelay = 32;
+uint8_t LEDControl::syncFPS = 30;
 uint16_t LEDControl::syncTimer = 0;
 bool LEDControl::enabled_ = true;
 Key LEDControl::pending_next_prev_key_ = Key_NoKey;
@@ -189,10 +189,12 @@ kaleidoscope::EventHandlerResult LEDControl::beforeReportingState(void) {
     pending_next_prev_key_ = Key_NoKey;
   }
 
-  if (Runtime.hasTimeExpired(syncTimer, syncDelay)) {
+  update();
+
+  uint8_t timer = 1000 / syncFPS;
+  if (Runtime.hasTimeExpired(syncTimer, timer)) {
     syncLeds();
-    syncTimer += syncDelay;
-    update();
+    syncTimer += timer;
   }
 
   return kaleidoscope::EventHandlerResult::OK;

--- a/src/kaleidoscope/plugin/LEDControl.cpp
+++ b/src/kaleidoscope/plugin/LEDControl.cpp
@@ -207,6 +207,7 @@ EventHandlerResult FocusLEDCommand::onFocusEvent(const char *command) {
     AT,
     THEME,
     BRIGHTNESS,
+    FPS,
   } subCommand;
 
   if (!Runtime.has_leds)
@@ -216,7 +217,8 @@ EventHandlerResult FocusLEDCommand::onFocusEvent(const char *command) {
                                        "led.setAll\n"
                                        "led.mode\n"
                                        "led.brightness\n"
-                                       "led.theme")))
+                                       "led.theme\n"
+                                       "led.fps")))
     return EventHandlerResult::OK;
 
   if (strncmp_P(command, PSTR("led."), 4) != 0)
@@ -231,6 +233,8 @@ EventHandlerResult FocusLEDCommand::onFocusEvent(const char *command) {
     subCommand = THEME;
   else if (strcmp_P(command + 4, PSTR("brightness")) == 0)
     subCommand = BRIGHTNESS;
+  else if (strcmp_P(command + 4, PSTR("fps")) == 0)
+    subCommand = FPS;
   else
     return EventHandlerResult::OK;
 
@@ -309,6 +313,17 @@ EventHandlerResult FocusLEDCommand::onFocusEvent(const char *command) {
       ::Focus.read(color);
 
       ::LEDControl.setCrgbAt(led_index.offset(), color);
+    }
+    break;
+  }
+  case FPS: {
+    if (::Focus.isEOL()) {
+      ::Focus.send(::LEDControl.getTargetFPS());
+    } else {
+      uint8_t fps;
+
+      ::Focus.read(fps);
+      ::LEDControl.setTargetFPS(fps);
     }
     break;
   }

--- a/src/kaleidoscope/plugin/LEDControl.h
+++ b/src/kaleidoscope/plugin/LEDControl.h
@@ -73,8 +73,10 @@ class LEDControl : public kaleidoscope::Plugin {
 
     set_all_leds_to({0, 0, 0});
 
-    if (cur_led_mode_ != nullptr)
+    if (cur_led_mode_ != nullptr) {
       cur_led_mode_->onActivate();
+      cur_led_mode_->setTargetFPS(syncFPS);
+    }
   }
 
   static void setCrgbAt(uint8_t led_index, cRGB crgb);
@@ -107,6 +109,16 @@ class LEDControl : public kaleidoscope::Plugin {
   }
   static uint8_t getBrightness() {
     return Runtime.device().ledDriver().getBrightness();
+  }
+
+  static void setTargetFPS(uint8_t fps) {
+    syncFPS = max(fps, 1);
+    if (cur_led_mode_ != nullptr) {
+      cur_led_mode_->setTargetFPS(syncFPS);
+    }
+  }
+  static uint8_t getTargetFPS() {
+    return syncFPS;
   }
 
  private:

--- a/src/kaleidoscope/plugin/LEDControl.h
+++ b/src/kaleidoscope/plugin/LEDControl.h
@@ -92,8 +92,6 @@ class LEDControl : public kaleidoscope::Plugin {
   //
   static void activate(LEDModeInterface *plugin);
 
-  static uint8_t syncDelay;
-
   kaleidoscope::EventHandlerResult onSetup();
   kaleidoscope::EventHandlerResult onKeyswitchEvent(Key &mappedKey, KeyAddr key_addr, uint8_t keyState);
   kaleidoscope::EventHandlerResult beforeReportingState();
@@ -112,6 +110,7 @@ class LEDControl : public kaleidoscope::Plugin {
   }
 
  private:
+  static uint8_t syncFPS;
   static uint16_t syncTimer;
   static uint8_t mode_id;
   static uint8_t num_led_modes_;

--- a/src/kaleidoscope/plugin/LEDControl/LEDUtils.cpp
+++ b/src/kaleidoscope/plugin/LEDControl/LEDUtils.cpp
@@ -117,3 +117,22 @@ hsvToRgb(uint16_t h, uint16_t s, uint16_t v) {
 
   return color;
 }
+
+// hue = 0-360, saturation = 0-255, value = 0-255
+cRGB
+hsvToRgb360(uint16_t hue, uint8_t saturation, uint8_t value) {
+  uint8_t chroma = (saturation * value) / 255;
+  uint8_t component = chroma * (100 - abs((hue * 100 / 60) % 200 - 100)) / 100;
+  uint8_t mod = value - chroma;
+  uint8_t region = hue / 60;
+
+  cRGB color = {mod, mod, mod};
+  color.r += (region == 0 || region == 5) ? chroma :
+    ((region == 1 || region == 4) ? component : 0);
+  color.g += (region == 1 || region == 2) ? chroma :
+    ((region == 0 || region == 3) ? component : 0);
+  color.b += (region == 3 || region == 4) ? chroma :
+    ((region == 2 || region == 5) ? component : 0);
+
+  return color;
+}

--- a/src/kaleidoscope/plugin/LEDControl/LEDUtils.cpp
+++ b/src/kaleidoscope/plugin/LEDControl/LEDUtils.cpp
@@ -118,15 +118,20 @@ hsvToRgb(uint16_t h, uint16_t s, uint16_t v) {
   return color;
 }
 
-// hue = 0-360, saturation = 0-255, value = 0-255
+// hue = 0-359, saturation = 0-255, value = 0-255
 cRGB
 hsvToRgb360(uint16_t hue, uint8_t saturation, uint8_t value) {
+  // Make sure the hue is within range
+  hue %= 360;
+
   uint8_t chroma = (saturation * value) / 255;
+
+  // Multiply by 100 to avoid slow floating point operations
   uint8_t component = chroma * (100 - abs((hue * 100 / 60) % 200 - 100)) / 100;
   uint8_t mod = value - chroma;
   uint8_t region = hue / 60;
 
-  cRGB color = {mod, mod, mod};
+  cRGB color = CRGB(mod, mod, mod);
   color.r += (region == 0 || region == 5) ? chroma :
     ((region == 1 || region == 4) ? component : 0);
   color.g += (region == 1 || region == 2) ? chroma :

--- a/src/kaleidoscope/plugin/LEDControl/LEDUtils.h
+++ b/src/kaleidoscope/plugin/LEDControl/LEDUtils.h
@@ -20,3 +20,4 @@
 
 cRGB breath_compute(uint8_t hue = 170, uint8_t saturation = 255, uint8_t phase_offset = 0);
 cRGB hsvToRgb(uint16_t h, uint16_t s, uint16_t v);
+cRGB hsvToRgb360(uint16_t hue, uint8_t saturation, uint8_t value);

--- a/src/kaleidoscope/plugin/LEDEffect-Rainbow.cpp
+++ b/src/kaleidoscope/plugin/LEDEffect-Rainbow.cpp
@@ -24,7 +24,7 @@ void LEDRainbowEffect::TransientLEDMode::update(void) {
     return;
 
   if (!Runtime.hasTimeExpired(rainbow_last_update,
-                              parent_->rainbow_update_delay)) {
+                              rainbow_update_delay)) {
     return;
   }
 
@@ -32,15 +32,11 @@ void LEDRainbowEffect::TransientLEDMode::update(void) {
   ::LEDControl.set_all_leds_to(rainbow);
 
   rainbow_hue = (rainbow_hue + rainbow_steps) % 360;
-  rainbow_last_update += parent_->rainbow_update_delay;
+  rainbow_last_update += rainbow_update_delay;
 }
 
 void LEDRainbowEffect::brightness(byte brightness) {
   rainbow_value = brightness;
-}
-
-void LEDRainbowEffect::update_delay(byte delay) {
-  rainbow_update_delay = delay;
 }
 
 
@@ -51,7 +47,7 @@ void LEDRainbowWaveEffect::TransientLEDMode::update(void) {
     return;
 
   if (!Runtime.hasTimeExpired(rainbow_last_update,
-                              parent_->rainbow_update_delay)) {
+                              rainbow_update_delay)) {
     return;
   }
 
@@ -61,16 +57,17 @@ void LEDRainbowWaveEffect::TransientLEDMode::update(void) {
     ::LEDControl.setCrgbAt(led_index.offset(), rainbow);
   }
 
-  rainbow_hue = (rainbow_hue + rainbow_wave_steps) % 360;
-  rainbow_last_update += parent_->rainbow_update_delay;
+  uint8_t hue_steps = max((rainbow_update_delay / 45), 1);
+  rainbow_hue = (rainbow_hue + hue_steps) % 360;
+  rainbow_last_update += rainbow_update_delay;
+}
+
+void LEDRainbowWaveEffect::TransientLEDMode::setTargetFPS(uint8_t fps) {
+  rainbow_update_delay = (1000 / fps) * 3;
 }
 
 void LEDRainbowWaveEffect::brightness(byte brightness) {
   rainbow_value = brightness;
-}
-
-void LEDRainbowWaveEffect::update_delay(byte delay) {
-  rainbow_update_delay = delay;
 }
 
 }

--- a/src/kaleidoscope/plugin/LEDEffect-Rainbow.cpp
+++ b/src/kaleidoscope/plugin/LEDEffect-Rainbow.cpp
@@ -31,11 +31,7 @@ void LEDRainbowEffect::TransientLEDMode::update(void) {
   cRGB rainbow = hsvToRgb360(rainbow_hue, rainbow_saturation, parent_->rainbow_value);
   ::LEDControl.set_all_leds_to(rainbow);
 
-  rainbow_hue += rainbow_steps;
-  if (rainbow_hue >= 360) {
-    rainbow_hue -= 360;
-  }
-
+  rainbow_hue = (rainbow_hue + rainbow_steps) % 360;
   rainbow_last_update += parent_->rainbow_update_delay;
 }
 
@@ -60,23 +56,12 @@ void LEDRainbowWaveEffect::TransientLEDMode::update(void) {
   }
 
   for (auto led_index : Runtime.device().LEDs().all()) {
-    uint16_t led_hue = rainbow_hue + 16 * (led_index.offset() / 4);
-    // We want led_hue to be capped at 360, but we do not want to clip it to
-    // that, because that does not result in a nice animation. Instead, when it
-    // is higher than 360, we simply substract 360, and repeat that until we're
-    // within cap. This lays out the rainbow in a kind of wave.
-    while (led_hue >= 360) {
-      led_hue -= 360;
-    }
-
+    uint16_t led_hue = (rainbow_hue + 16 * (led_index.offset() / 4)) % 360;
     cRGB rainbow = hsvToRgb360(led_hue, rainbow_saturation, parent_->rainbow_value);
     ::LEDControl.setCrgbAt(led_index.offset(), rainbow);
   }
-  rainbow_hue += rainbow_wave_steps;
-  if (rainbow_hue >= 360) {
-    rainbow_hue -= 360;
-  }
 
+  rainbow_hue = (rainbow_hue + rainbow_wave_steps) % 360;
   rainbow_last_update += parent_->rainbow_update_delay;
 }
 

--- a/src/kaleidoscope/plugin/LEDEffect-Rainbow.cpp
+++ b/src/kaleidoscope/plugin/LEDEffect-Rainbow.cpp
@@ -26,17 +26,17 @@ void LEDRainbowEffect::TransientLEDMode::update(void) {
   if (!Runtime.hasTimeExpired(rainbow_last_update,
                               parent_->rainbow_update_delay)) {
     return;
-  } else {
-    rainbow_last_update += parent_->rainbow_update_delay;
   }
 
-  cRGB rainbow = hsvToRgb(rainbow_hue, rainbow_saturation, parent_->rainbow_value);
+  cRGB rainbow = hsvToRgb360(rainbow_hue, rainbow_saturation, parent_->rainbow_value);
+  ::LEDControl.set_all_leds_to(rainbow);
 
   rainbow_hue += rainbow_steps;
-  if (rainbow_hue >= 255) {
-    rainbow_hue -= 255;
+  if (rainbow_hue >= 360) {
+    rainbow_hue -= 360;
   }
-  ::LEDControl.set_all_leds_to(rainbow);
+
+  rainbow_last_update += parent_->rainbow_update_delay;
 }
 
 void LEDRainbowEffect::brightness(byte brightness) {
@@ -57,27 +57,27 @@ void LEDRainbowWaveEffect::TransientLEDMode::update(void) {
   if (!Runtime.hasTimeExpired(rainbow_last_update,
                               parent_->rainbow_update_delay)) {
     return;
-  } else {
-    rainbow_last_update += parent_->rainbow_update_delay;
   }
 
   for (auto led_index : Runtime.device().LEDs().all()) {
     uint16_t led_hue = rainbow_hue + 16 * (led_index.offset() / 4);
-    // We want led_hue to be capped at 255, but we do not want to clip it to
+    // We want led_hue to be capped at 360, but we do not want to clip it to
     // that, because that does not result in a nice animation. Instead, when it
-    // is higher than 255, we simply substract 255, and repeat that until we're
+    // is higher than 360, we simply substract 360, and repeat that until we're
     // within cap. This lays out the rainbow in a kind of wave.
-    while (led_hue >= 255) {
-      led_hue -= 255;
+    while (led_hue >= 360) {
+      led_hue -= 360;
     }
 
-    cRGB rainbow = hsvToRgb(led_hue, rainbow_saturation, parent_->rainbow_value);
+    cRGB rainbow = hsvToRgb360(led_hue, rainbow_saturation, parent_->rainbow_value);
     ::LEDControl.setCrgbAt(led_index.offset(), rainbow);
   }
   rainbow_hue += rainbow_wave_steps;
-  if (rainbow_hue >= 255) {
-    rainbow_hue -= 255;
+  if (rainbow_hue >= 360) {
+    rainbow_hue -= 360;
   }
+
+  rainbow_last_update += parent_->rainbow_update_delay;
 }
 
 void LEDRainbowWaveEffect::brightness(byte brightness) {

--- a/src/kaleidoscope/plugin/LEDEffect-Rainbow.h
+++ b/src/kaleidoscope/plugin/LEDEffect-Rainbow.h
@@ -54,14 +54,14 @@ class LEDRainbowEffect : public Plugin,
 
     uint16_t rainbow_hue = 0;   //  stores 0 to 614
 
-    uint8_t rainbow_steps = 1;  //  number of hues we skip in a 360 range per update
+    uint8_t rainbow_steps = 2;  //  number of hues we skip in a 360 range per update
     uint8_t rainbow_last_update = 0;
 
     byte rainbow_saturation = 255;
   };
 
  private:
-  uint8_t rainbow_update_delay = 40; // delay between updates (ms)
+  uint8_t rainbow_update_delay = 90; // delay between updates (ms)
   byte rainbow_value = 50;
 };
 
@@ -99,13 +99,13 @@ class LEDRainbowWaveEffect : public Plugin, public LEDModeInterface {
 
     uint16_t rainbow_hue = 0;  //  stores 0 to 614
 
-    uint8_t rainbow_wave_steps = 1;  //  number of hues we skip in a 360 range per update
+    uint8_t rainbow_wave_steps = 2;  //  number of hues we skip in a 360 range per update
     uint8_t rainbow_last_update = 0;
 
     byte rainbow_saturation = 255;
   };
 
-  uint8_t rainbow_update_delay = 40; // delay between updates (ms)
+  uint8_t rainbow_update_delay = 90; // delay between updates (ms)
   byte rainbow_value = 50;
 };
 }

--- a/src/kaleidoscope/plugin/LEDEffect-Rainbow.h
+++ b/src/kaleidoscope/plugin/LEDEffect-Rainbow.h
@@ -29,10 +29,6 @@ class LEDRainbowEffect : public Plugin,
   byte brightness(void) {
     return rainbow_value;
   }
-  void update_delay(byte);
-  byte update_delay(void) {
-    return rainbow_update_delay;
-  }
 
   // This class' instance has dynamic lifetime
   //
@@ -56,12 +52,12 @@ class LEDRainbowEffect : public Plugin,
 
     uint8_t rainbow_steps = 2;  //  number of hues we skip in a 360 range per update
     uint8_t rainbow_last_update = 0;
+    uint8_t rainbow_update_delay = 90;
 
     byte rainbow_saturation = 255;
   };
 
  private:
-  uint8_t rainbow_update_delay = 90; // delay between updates (ms)
   byte rainbow_value = 50;
 };
 
@@ -73,10 +69,6 @@ class LEDRainbowWaveEffect : public Plugin, public LEDModeInterface {
   void brightness(byte);
   byte brightness(void) {
     return rainbow_value;
-  }
-  void update_delay(byte);
-  byte update_delay(void) {
-    return rainbow_update_delay;
   }
 
   // This class' instance has dynamic lifetime
@@ -93,19 +85,20 @@ class LEDRainbowWaveEffect : public Plugin, public LEDModeInterface {
 
     void update() final;
 
+    void setTargetFPS(uint8_t fps) final;
+
    private:
 
     const LEDRainbowWaveEffect *parent_;
 
+    uint8_t rainbow_update_delay = 90;
     uint16_t rainbow_hue = 0;  //  stores 0 to 614
 
-    uint8_t rainbow_wave_steps = 2;  //  number of hues we skip in a 360 range per update
     uint8_t rainbow_last_update = 0;
 
     byte rainbow_saturation = 255;
   };
 
-  uint8_t rainbow_update_delay = 90; // delay between updates (ms)
   byte rainbow_value = 50;
 };
 }

--- a/src/kaleidoscope/plugin/LEDMode.h
+++ b/src/kaleidoscope/plugin/LEDMode.h
@@ -92,6 +92,16 @@ class LEDMode : public kaleidoscope::Plugin,
    */
   virtual void refreshAt(KeyAddr key_addr) {}
 
+  /* Set the target FPS
+   *
+   * This changes how many times the LEDs are updated per second and any
+   * calculations that affect speed and such should take this into
+   * account to get smooth animations.
+   *
+   * @param fps the target FPS
+   */
+  virtual void setTargetFPS(uint8_t fps) {}
+
  public:
 
   /** Plugin initialization.


### PR DESCRIPTION
I noticed that when using the rainbow LED effect the latency of the keyboard would increase drastically, simply due to the amount of LEDs needing to be updated. This PR aims to improve that by changing the LED handling a bit to make it smoother.
For one it writes the changes to the LEDs based on a target FPS rather than a ms value (they're essentially the same thing, but specifying an FPS makes more sense). The processing code is also no longer tied to the LED sync code either, so the processing can happen independently of the LED sync. The rainbow effect also doesn't update as often, but should have essentially the same speed as before.
I also decided to add a custom hsv to rgb function as I found the existing one to be quite confusing, and this new one supports the full 0-360 degrees hue as well as saturation and value in the 0-255 range.

Let me know if the updating is a bit too slow, or if anything else can be improved. To me it looks fine, and identical to how it was before, but it might look different through someone else's eyes,