### PR TITLE
Add preliminary HostPowerManagement support for SAMD.

### DIFF
--- a/src/kaleidoscope/plugin/HostPowerManagement.h
+++ b/src/kaleidoscope/plugin/HostPowerManagement.h
@@ -42,7 +42,13 @@ class HostPowerManagement : public kaleidoscope::Plugin {
 
  private:
   static bool was_suspended_;
+#ifdef __AVR__
   static bool initial_suspend_;
+#elif defined(ARDUINO_SAMD_RAISE)
+  static uint16_t suspend_timer;
+  static uint16_t saved_fnum;
+  static uint8_t fnum_counter;
+#endif
 };
 }
 

--- a/src/kaleidoscope/plugin/HostPowerManagement.h
+++ b/src/kaleidoscope/plugin/HostPowerManagement.h
@@ -44,7 +44,7 @@ class HostPowerManagement : public kaleidoscope::Plugin {
   static bool was_suspended_;
 #ifdef __AVR__
   static bool initial_suspend_;
-#elif defined(ARDUINO_SAMD_RAISE)
+#elif defined ARDUINO_ARCH_SAMD
   static uint16_t suspend_timer;
   static uint16_t saved_fnum;
   static uint8_t fnum_counter;


### PR DESCRIPTION
This PR adds preliminary support for the suspend and resume events when using HostPowerManagement for SAMD. It does this by checking the USB frame number, and if it hasn't changed within 1000 milliseconds it'll assume the device is suspended. This works because when the USB port is active the frame number will keep changing and when suspended the host will mark the USB port as inactive and the communication will stop.
I've made it check the frame number quite often as I wanted to do as many checks as possible within those 1000 milliseconds. This can be lowered though if it seems to affect performance (from my testing it doesn't seem to).

Before I did this I tried messing about with interrupts and such, but none of them seemed to actually register when suspending or resuming, so I feel like this method is as good as we're going to get.

I've also implemented the HostPowerManagement plugin to Raise-Firmware, which I'm going to push to that repo.