### PR TITLE
Use a linear calculation for the red LED channel

### DIFF
--- a/src/kaleidoscope/device/dygma/raise/Hand.cpp
+++ b/src/kaleidoscope/device/dygma/raise/Hand.cpp
@@ -237,7 +237,7 @@ void Hand::sendLEDBank(uint8_t bank) {
     //
     // FIXME(@anyone): This should eventually be configurable someway.
     if ((i + 1) % 3 == 1) {
-      data[i + 1] = (data[i + 1] >= 26) ? data[i + 1] - 26 : 0;
+      data[i + 1] = data[i + 1] * red_max_fraction_ / 100;
     }
   }
   uint8_t result = twi_.writeTo(data, ELEMENTS(data));

--- a/src/kaleidoscope/device/dygma/raise/Hand.h
+++ b/src/kaleidoscope/device/dygma/raise/Hand.h
@@ -41,6 +41,8 @@ namespace raise {
 #define LEDS_PER_BANK 8
 #define LED_BYTES_PER_BANK (sizeof(cRGB) * LEDS_PER_BANK)
 
+#define LED_RED_CHANNEL_MAX 229
+
 typedef union {
   cRGB leds[LEDS_PER_HAND];
   byte bytes[LED_BANKS][LED_BYTES_PER_BANK];
@@ -97,6 +99,7 @@ class Hand {
   TWI twi_;
   keydata_t key_data_;
   uint8_t next_led_bank_ = 0;
+  uint8_t red_max_fraction_ = (LED_RED_CHANNEL_MAX * 100) / 255;
 
   static constexpr uint8_t i2c_addr_base_ = 0x58;
 


### PR DESCRIPTION
Rather than simply removing 26 from the red channel, this uses a simple linear calculation to reduce it. This works much better because on low brightness the colour is very inaccurate - white, for example, turns into a blue/green colour.